### PR TITLE
Add offline SwiftUI marathon training planner

### DIFF
--- a/DayView.swift
+++ b/DayView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct DayView: View {
+    let title: String
+    let detail: String
+    let weekKey: String
+    let itemKey: String
+    @AppStorage private var completed: Bool
+    @AppStorage private var notes: String
+    @Environment(\.dismiss) private var dismiss
+
+    init(title: String, detail: String, weekKey: String, itemKey: String) {
+        self.title = title
+        self.detail = detail
+        self.weekKey = weekKey
+        self.itemKey = itemKey
+        _completed = AppStorage("completion.\(weekKey).\(itemKey)", defaultValue: false)
+        _notes = AppStorage("notes.\(weekKey).\(itemKey)", defaultValue: "")
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Workout") { Text(detail) }
+                Section("Notes") { TextEditor(text: $notes).frame(minHeight: 100) }
+                Toggle("Completed", isOn: $completed)
+            }
+            .navigationTitle(title)
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+}

--- a/MarathonLiteApp.swift
+++ b/MarathonLiteApp.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+@main
+struct MarathonLiteApp: App {
+    @StateObject private var store = PlanStore()
+    var body: some Scene {
+        WindowGroup {
+            WeeksView()
+                .environmentObject(store)
+        }
+    }
+}

--- a/Models.swift
+++ b/Models.swift
@@ -1,0 +1,213 @@
+import Foundation
+
+struct Plan: Decodable {
+    let meta: Meta
+    let globalGuidelines: GlobalGuidelines
+    let weeks: [Week]
+
+    enum CodingKeys: String, CodingKey {
+        case meta
+        case globalGuidelines = "global_guidelines"
+        case weeks
+    }
+}
+
+struct Meta: Decodable {
+    let athlete: String
+    let raceDate: String
+    let goal: String
+    let targetPaceKm: String
+    let trainingWindowLocal: String
+    let environment: String
+    let version: String
+
+    enum CodingKeys: String, CodingKey {
+        case athlete
+        case raceDate = "race_date"
+        case goal
+        case targetPaceKm = "target_pace_km"
+        case trainingWindowLocal = "training_window_local"
+        case environment
+        case version
+    }
+}
+
+struct GlobalGuidelines: Decodable {
+    let effortBasedOutdoors: EffortBased
+    let heatIndexSwitch: [HeatIndex]
+    let coolingFueling: CoolingFueling
+
+    enum CodingKeys: String, CodingKey {
+        case effortBasedOutdoors = "effort_based_outdoors"
+        case heatIndexSwitch = "heat_index_switch"
+        case coolingFueling = "cooling_fueling"
+    }
+}
+
+struct EffortBased: Decodable {
+    let description: String
+    let easyHrCapBpm: Int
+    let notes: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case description
+        case easyHrCapBpm = "easy_hr_cap_bpm"
+        case notes
+    }
+}
+
+struct HeatIndex: Decodable {
+    let condition: String
+    let action: String
+}
+
+struct CoolingFueling: Decodable {
+    let pre: String
+    let during: String
+    let post: String
+}
+
+struct Week: Identifiable, Decodable {
+    let id = UUID()
+    let number: Int?
+    let numberRange: [Int]?
+    let dateRange: String
+    let type: WeekType
+    let days: [Day]?
+    let weeklyVolumeKm: String?
+    let notes: [String]?
+    let sessionCategories: [SessionCategory]?
+
+    enum WeekType: String, Decodable { case detailed, guideline }
+
+    enum CodingKeys: String, CodingKey {
+        case number
+        case numberRange = "number_range"
+        case dateRange = "date_range"
+        case type
+        case days
+        case weeklyVolumeKm = "weekly_volume_km"
+        case notes
+        case sessions
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        number = try container.decodeIfPresent(Int.self, forKey: .number)
+        numberRange = try container.decodeIfPresent([Int].self, forKey: .numberRange)
+        dateRange = try container.decode(String.self, forKey: .dateRange)
+        type = try container.decode(WeekType.self, forKey: .type)
+        days = try container.decodeIfPresent([Day].self, forKey: .days)
+        weeklyVolumeKm = try container.decodeIfPresent(String.self, forKey: .weeklyVolumeKm)
+        notes = try container.decodeIfPresent([String].self, forKey: .notes)
+
+        if let sessionsDict = try container.decodeIfPresent([String: AnyDecodable].self, forKey: .sessions) {
+            var cats: [SessionCategory] = []
+            for (key, value) in sessionsDict {
+                if let arr = value.value as? [[String: Any]] {
+                    let items = arr.map { dict -> String in
+                        if let option = dict["option"], let session = dict["session"] {
+                            return "\(option): \(session)"
+                        } else if let session = dict["session"] {
+                            return "\(session)"
+                        } else {
+                            return dict.values.map { "\($0)" }.joined(separator: " ")
+                        }
+                    }
+                    cats.append(SessionCategory(name: key, items: items))
+                } else if let arr = value.value as? [String] {
+                    cats.append(SessionCategory(name: key, items: arr))
+                } else if let str = value.value as? String {
+                    cats.append(SessionCategory(name: key, items: [str]))
+                }
+            }
+            sessionCategories = cats
+        } else {
+            sessionCategories = nil
+        }
+    }
+
+    var storageKey: String {
+        if let n = number { return "\(n)" }
+        if let r = numberRange { return "\(r.first ?? 0)-\(r.last ?? 0)" }
+        return dateRange
+    }
+
+    var displayNumber: String {
+        if let n = number { return "\(n)" }
+        if let r = numberRange { return "\(r.first ?? 0)–\(r.last ?? 0)" }
+        return ""
+    }
+
+    var totalMinutes: Int {
+        days?.compactMap { $0.durationMin }.reduce(0,+) ?? 0
+    }
+}
+
+struct SessionCategory: Identifiable {
+    let id = UUID()
+    let name: String
+    let items: [String]
+}
+
+struct Day: Identifiable, Decodable {
+    let id = UUID()
+    let day: String
+    let type: String
+    let details: [String: String]
+    let durationMin: Int?
+
+    enum CodingKeys: CodingKey {
+        case day, type, extras, format, duration_min, hr_cap_bpm, env, zone, strides, blocks, grade_percent, drink_ml, hr_max_bpm, total_min, note, cross_train_min, strength_min, focus, repeats, warmup_min, recover_min, cooldown_min, steady_min, mp_feel_min, pace_km, work_min, intensity, hr_bpm, finish
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        day = try container.decode(String.self, forKey: .day)
+        type = try container.decode(String.self, forKey: .type)
+
+        var temp: [String: String] = [:]
+        var duration: Int? = nil
+
+        for key in container.allKeys where key != .day && key != .type {
+            if key == .duration_min {
+                if let intVal = try? container.decode(Int.self, forKey: .duration_min) {
+                    duration = intVal
+                    temp[key.stringValue] = "\(intVal)"
+                } else if let strVal = try? container.decode(String.self, forKey: .duration_min) {
+                    duration = Int(strVal.split(separator: "–").first ?? "")
+                    temp[key.stringValue] = strVal
+                }
+            } else if let str = try? container.decode(String.self, forKey: key) {
+                temp[key.stringValue] = str
+            } else if let int = try? container.decode(Int.self, forKey: key) {
+                temp[key.stringValue] = "\(int)"
+            } else if let arrStr = try? container.decode([String].self, forKey: key) {
+                temp[key.stringValue] = arrStr.joined(separator: ", ")
+            } else if let arrInt = try? container.decode([Int].self, forKey: key) {
+                temp[key.stringValue] = arrInt.map(String.init).joined(separator: ", ")
+            } else if let arrDict = try? container.decode([[String: String]].self, forKey: key) {
+                let data = (try? JSONSerialization.data(withJSONObject: arrDict)) ?? Data()
+                temp[key.stringValue] = String(data: data, encoding: .utf8) ?? ""
+            }
+        }
+        details = temp
+        durationMin = duration
+    }
+
+    var summary: String {
+        details.map { "\($0.key): \($0.value)" }.sorted().joined(separator: ", ")
+    }
+}
+
+struct AnyDecodable: Decodable {
+    let value: Any
+    init(from decoder: Decoder) throws {
+        if let int = try? Int(from: decoder) { value = int }
+        else if let dbl = try? Double(from: decoder) { value = dbl }
+        else if let str = try? String(from: decoder) { value = str }
+        else if let arr = try? [AnyDecodable](from: decoder) { value = arr.map{ $0.value } }
+        else if let dict = try? [String: AnyDecodable](from: decoder) { value = dict.mapValues{ $0.value } }
+        else { value = "" }
+    }
+}

--- a/PlanStore.swift
+++ b/PlanStore.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+final class PlanStore: ObservableObject {
+    @Published var plan: Plan
+
+    init() {
+        guard let url = Bundle.main.url(forResource: "plan", withExtension: "json"),
+              let data = try? Data(contentsOf: url),
+              let plan = try? JSONDecoder().decode(Plan.self, from: data) else {
+            fatalError("Unable to load plan.json")
+        }
+        self.plan = plan
+    }
+
+    func progress(for week: Week) -> Double {
+        guard let days = week.days else { return 0 }
+        var completed = 0
+        for index in days.indices {
+            if UserDefaults.standard.bool(forKey: "completion.\(week.storageKey).\(index)") {
+                completed += 1
+            }
+        }
+        return Double(completed) / Double(days.count)
+    }
+}

--- a/ProgressRing.swift
+++ b/ProgressRing.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct ProgressRing: View {
+    var progress: Double
+    var body: some View {
+        ZStack {
+            Circle().stroke(Color.gray.opacity(0.3), lineWidth: 6)
+            Circle()
+                .trim(from: 0, to: progress)
+                .stroke(Color.accentColor, style: StrokeStyle(lineWidth: 6, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
-# monotone-ios
-A tiny single-screen SwiftUI notes app for personal use (local-only).
+# MarathonLite
+
+Minimal offline SwiftUI iPhone app that loads a marathon training plan from a bundled JSON file.
+
+## Run on Device
+1. Open the project in Xcode 15 or later.
+2. Select an iPhone target running iOS 16+.
+3. Build and run; `plan.json` is bundled so the app works offline.

--- a/WeekDetailView.swift
+++ b/WeekDetailView.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+
+struct WeekDetailView: View {
+    let week: Week
+    
+    var body: some View {
+        List {
+            if week.type == .detailed, let days = week.days {
+                ForEach(Array(days.enumerated()), id: \.0) { idx, day in
+                    DayRow(week: week, day: day, index: idx)
+                }
+                if week.totalMinutes > 0 {
+                    Section {
+                        Text("Total minutes: \(week.totalMinutes)")
+                    }
+                }
+            } else if let cats = week.sessionCategories {
+                ForEach(cats) { cat in
+                    Section(header: Text(cat.name)) {
+                        ForEach(Array(cat.items.enumerated()), id: \.0) { idx, item in
+                            SessionRow(week: week, category: cat.name, item: item, index: idx)
+                        }
+                    }
+                }
+            }
+            if let notes = week.notes, !notes.isEmpty {
+                Section("Notes") {
+                    ForEach(notes, id: \.self) { note in
+                        Text(note)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Week \(week.displayNumber)")
+        .toolbar {
+            if #available(iOS 16.0, *) {
+                ShareLink(item: shareText) {
+                    Image(systemName: "square.and.arrow.up")
+                }
+            }
+        }
+    }
+    
+    var shareText: String {
+        var parts: [String] = []
+        if week.type == .detailed, let days = week.days {
+            for day in days {
+                parts.append("\(day.day): \(day.type) \(day.summary)")
+            }
+        } else if let cats = week.sessionCategories {
+            for cat in cats {
+                parts.append("\(cat.name):")
+                for item in cat.items { parts.append("- \(item)") }
+            }
+        }
+        return parts.joined(separator: "\n")
+    }
+}
+
+struct DayRow: View {
+    let week: Week
+    let day: Day
+    let index: Int
+    @AppStorage var completed: Bool
+    @State private var showSheet = false
+
+    init(week: Week, day: Day, index: Int) {
+        self.week = week
+        self.day = day
+        self.index = index
+        _completed = AppStorage("completion.\(week.storageKey).\(index)")
+    }
+
+    var body: some View {
+        Button {
+            showSheet = true
+        } label: {
+            HStack {
+                VStack(alignment: .leading) {
+                    Text(day.day)
+                    Text(day.type).font(.subheadline)
+                }
+                Spacer()
+                if completed {
+                    Image(systemName: "checkmark.circle.fill").foregroundColor(.green)
+                }
+            }
+        }
+        .sheet(isPresented: $showSheet) {
+            DayView(title: day.day, detail: "\(day.type)\n\(day.summary)", weekKey: week.storageKey, itemKey: "\(index)")
+        }
+    }
+}
+
+struct SessionRow: View {
+    let week: Week
+    let category: String
+    let item: String
+    let index: Int
+    @AppStorage var completed: Bool
+    @State private var showSheet = false
+
+    init(week: Week, category: String, item: String, index: Int) {
+        self.week = week
+        self.category = category
+        self.item = item
+        self.index = index
+        let key = "completion.\(week.storageKey).\(category.replacingOccurrences(of: " ", with: "_"))\(index)"
+        _completed = AppStorage(key)
+    }
+
+    var body: some View {
+        Button { showSheet = true } label: {
+            HStack {
+                Text(item)
+                Spacer()
+                if completed {
+                    Image(systemName: "checkmark.circle.fill").foregroundColor(.green)
+                }
+            }
+        }
+        .sheet(isPresented: $showSheet) {
+            let key = "\(category.replacingOccurrences(of: " ", with: "_"))\(index)"
+            DayView(title: item, detail: "", weekKey: week.storageKey, itemKey: key)
+        }
+    }
+}

--- a/WeeksView.swift
+++ b/WeeksView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct WeeksView: View {
+    @EnvironmentObject var store: PlanStore
+
+    var body: some View {
+        NavigationStack {
+            List(store.plan.weeks) { week in
+                NavigationLink(destination: WeekDetailView(week: week)) {
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text("Week \(week.displayNumber)")
+                                .font(.headline)
+                            Text(week.dateRange)
+                                .font(.subheadline)
+                        }
+                        Spacer()
+                        if week.type == .detailed {
+                            ProgressRing(progress: store.progress(for: week))
+                                .frame(width: 32, height: 32)
+                        } else {
+                            Text("Guide")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Weeks")
+        }
+    }
+}

--- a/plan.json
+++ b/plan.json
@@ -1,0 +1,131 @@
+{
+  "meta": {
+    "athlete": "Francisco",
+    "race_date": "2026-01-15",
+    "goal": "sub-4:00",
+    "target_pace_km": "5:41/km",
+    "training_window_local": "19:00–21:00",
+    "environment": "Doha evenings; high heat & humidity Aug–Oct",
+    "version": "Evening v2.1 (heat-adjusted)"
+  },
+  "global_guidelines": {
+    "effort_based_outdoors": {
+      "description": "Train by effort (HR/RPE). Use treadmill/AC for quality when nights are hot/humid.",
+      "easy_hr_cap_bpm": 155,
+      "notes": [
+        "If HR >155 bpm for >60 s in easy runs, use run–walk until it drops.",
+        "Quality sessions indoors if WBGT/heat index is high."
+      ]
+    },
+    "heat_index_switch": [
+      {"condition": "HI≥40 or T≥33°C & RH≥60%", "action": "Move quality to treadmill; convert long run to time-on-feet + run–walk"},
+      {"condition": "HI 29–31°C", "action": "Keep work ≤40 min, extend recoveries, expect +8–12% slower"},
+      {"condition": "HI≤28°C", "action": "Resume normal targets"}
+    ],
+    "cooling_fueling": {
+      "pre": "15–20 min AC; ice towel/vest optional; 300–400 ml ice slushy",
+      "during": "0.4–0.8 L/h with 300–600 mg sodium/h; sip every 10–15 min",
+      "post": "10–15 min cool shower/ice bath; rehydrate 150% of losses within 2–4 h"
+    }
+  },
+  "weeks": [
+    {
+      "number": 1,
+      "date_range": "2025-08-31 → 2025-09-06",
+      "type": "detailed",
+      "days": [
+        {"day":"Mon","type":"rest","extras":["mobility 20 min","light core"]},
+        {"day":"Tue","type":"easy","format":"run–walk 2’/1’","duration_min":40,"hr_cap_bpm":150,"strides":"4×100 m if HR<145"},
+        {"day":"Wed","type":"cross-train","env":"AC","duration_min":45,"zone":"Z2","extras":["glute/core"]},
+        {"day":"Thu","type":"treadmill_tempo","total_min":"35–40","blocks":[{"warmup_min":10},{"repeats":3,"work_min":6,"intensity":"comfortably hard","hr_max_bpm":160,"recover_min":3},{"cooldown_min":10}]},
+        {"day":"Fri","type":"recovery_jog","duration_min":"25–30","env":"outdoor if breezy; else treadmill"},
+        {"day":"Sat","type":"treadmill_endurance","duration_min":60,"zone":"Z2","grade_percent":"1–2%","drink_ml":"400–600"},
+        {"day":"Sun","type":"long_run","env":"outdoor PM","duration_min":"70–80","format":"run–walk 3’/1’","hr_cap_bpm":155}
+      ]
+    },
+    {
+      "number": 2,
+      "date_range": "2025-09-07 → 2025-09-13",
+      "type": "detailed",
+      "days": [
+        {"day":"Mon","type":"rest","extras":["mobility"]},
+        {"day":"Tue","type":"easy","duration_min":45,"format":"run–walk 3’/1’","hr_cap_bpm":150},
+        {"day":"Wed","type":"cross-train","env":"AC","duration_min":50,"zone":"Z2"},
+        {"day":"Thu","type":"treadmill_intervals","total_min":"50–55","blocks":[{"warmup_min":15},{"repeats":6,"work_min":3,"intensity":"~10K effort","hr_bpm":"158–165","recover_min":2},{"cooldown_min":10}]},
+        {"day":"Fri","type":"recovery_jog","duration_min":30},
+        {"day":"Sat","type":"treadmill_endurance","duration_min":70,"zone":"Z2","finish":"last 10’ optional Z3 if fresh"},
+        {"day":"Sun","type":"long_run","duration_min":"85–90","format":"run–walk 4’/1’","hr_cap_bpm":155}
+      ]
+    },
+    {
+      "number": 3,
+      "date_range": "2025-09-14 → 2025-09-20",
+      "type": "detailed",
+      "days": [
+        {"day":"Mon","type":"rest"},
+        {"day":"Tue","type":"easy","duration_min":50,"format":"continuous (run–walk only if HR>150)"},
+        {"day":"Wed","type":"cross-train","env":"AC","duration_min":"45–50"},
+        {"day":"Thu","type":"treadmill_progression","total_min":"55–60","blocks":[{"warmup_min":15},{"steady_min":20,"hr_bpm":"150–158"},{"mp_feel_min":10,"pace_km":"5:35–5:45","hr_max_bpm":162},{"cooldown_min":10}]},
+        {"day":"Fri","type":"recovery_jog","duration_min":30,"extras":["drills"]},
+        {"day":"Sat","type":"treadmill_uphill","duration_min":50,"zone":"Z2","grade_percent":"3–4%"},
+        {"day":"Sun","type":"long_run","duration_min":"95–100","format":"start 4’/1’; last 20’ continuous if HR≤155"}
+      ]
+    },
+    {
+      "number": 4,
+      "date_range": "2025-09-21 → 2025-09-27",
+      "type": "detailed",
+      "days": [
+        {"day":"Mon","type":"rest"},
+        {"day":"Tue","type":"easy","duration_min":45,"hr_cap_bpm":145},
+        {"day":"Wed","type":"cross-train+strength","env":"AC","cross_train_min":"40–45","strength_min":25,"focus":["single-leg","core"]},
+        {"day":"Thu","type":"treadmill_threshold","total_min":"45–50","blocks":[{"warmup_min":12},{"repeats":3,"work_min":8,"intensity":"LT feel (RPE 7/10)","hr_bpm":"160–164","recover_min":3},{"cooldown_min":8}]},
+        {"day":"Fri","type":"recovery_jog","duration_min":"25–30"},
+        {"day":"Sat","type":"off_or_swim","note":"gentle swim optional"},
+        {"day":"Sun","type":"long_run","duration_min":"80–85","format":"run–walk 3’/1’"}
+      ]
+    },
+    {
+      "number_range":[5,8],
+      "date_range":"2025-09-28 → 2025-10-25",
+      "type":"guideline",
+      "weekly_volume_km":"52–64 per week",
+      "notes":["Re-introduce controlled outdoor work when evening lows ≤30°C."],
+      "sessions":{
+        "quality_1x":[
+          {"option":"outdoor steady","session":"4–5×6’ @ upper Z3 (HR 155–160) w/ 3’ jog"},
+          {"option":"treadmill HM","session":"5×1.6 km @ ~HM effort (HR 160–165) w/ 600 m easy"}
+        ],
+        "tempo_1x":"Build to 2×15’ @ strong aerobic (HR 158–162)",
+        "long_run":"1h45 → 2h10, last 20–30’ steady if HR ≤160",
+        "easy_days":"30–55 min Z2, optional strides"
+      }
+    },
+    {
+      "number_range":[9,16],
+      "date_range":"2025-10-26 → 2025-12-21",
+      "type":"guideline",
+      "weekly_volume_km":"64–90+ per week",
+      "notes":["Evenings typically ≤28°C; progress to full race-pace work."],
+      "sessions":{
+        "rotate_2_of_3":[
+          "Intervals: 5×1.6 km @ ~10K pace (HR 165–172), 2–3’ jog",
+          "Tempo: 8–11 km continuous @ LT (HR 162–168)",
+          "Long run with MP: 26–32 km with 10–16 km @ MP (≈5:29–5:35/km) if conditions cool; else by HR ≤167"
+        ],
+        "strength":"1×/week 30–40 min (single-leg RDL, step-ups, calf raises, trunk)"
+      }
+    },
+    {
+      "number_range":[17,20],
+      "date_range":"2025-12-22 → 2026-01-15",
+      "type":"guideline",
+      "weekly_volume_km":"Taper: reduce from ~70 → 40 km",
+      "notes":["Keep intensity touches short; protect freshness."],
+      "sessions":{
+        "wk17_19":"1 short interval set (e.g., 6×400 m @ 5K feel) + one MP touch 5–8 km",
+        "race_week":"2–3 easy runs + short strides; all Zone 2; carb load 7–10 g/kg in last 48 h"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `plan.json` marathon training schedule and models for detailed and guideline weeks
- show weeks list with progress rings and week detail screens with share/export
- persist completion and notes via AppStorage in day/session sheets

## Testing
- `swiftc MarathonLiteApp.swift Models.swift PlanStore.swift WeeksView.swift WeekDetailView.swift DayView.swift ProgressRing.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68b35bc13854832db49495160a3db1af